### PR TITLE
Check if fee is not none

### DIFF
--- a/kin_base/transaction.py
+++ b/kin_base/transaction.py
@@ -71,7 +71,7 @@ class Transaction(object):
         if fee is not None:
             if not isinstance(fee, int):
                 raise NotValidParamError('Fee must be an integer')
-        self.fee = int(fee) if fee else self.default_fee
+        self.fee = int(fee) if fee is not None else self.default_fee
         self.operations = operations or []
         # self.time_bounds = [time_bounds['minTime'],
         #                     time_bounds['maxTime']] if time_bounds else []


### PR DESCRIPTION
If fee was 0, it would be considered 'False', so the transaction used the default fee.

Fixed it by checking if the fee is not None instead of checking if its true